### PR TITLE
Fix tool links

### DIFF
--- a/views/nonautomated_edits/about.haml
+++ b/views/nonautomated_edits/about.haml
@@ -26,7 +26,7 @@
         %span.id>
           = tool[:id]
         %span.name>
-          %a{href: "#{projectPath}/#{tool[:link]}"}
+          %a{href: "#{projectPath}/wiki/#{tool[:link]}"}
             = tool[:name]
         %span.regex>
           = tool[:regex]


### PR DESCRIPTION
Tools were linking on [the nonautomated edits page](https://tools.wmflabs.org/musikanimal/nonautomated_edits/about) in form https://en.wikipedia.org/WP:AWB rather than the correct https://en.wikipedia.org/wiki/WP:AWB

I think this fixes it, I am very possibly wrong.
