### PR TITLE
Fix repeated or erroneous units in replication lag

### DIFF
--- a/views/blp_edits/summary.handlebars
+++ b/views/blp_edits/summary.handlebars
@@ -1,4 +1,4 @@
-{{#if replication_lag}}<p class='error'>High replication lag: Data newer than {{replication_lag}} seconds may not be shown</p>{{/if}}
+{{#if replication_lag}}<p class='error'>High replication lag: Data newer than {{replication_lag}} may not be shown</p>{{/if}}
 <a href="{{project_path}}/wiki/User:{{username}}">{{username}}</a> has approximently {{#if nonautomated}}<b>{{nonautomated_blp_count}}</b> non-automated{{else}}<b>{{blp_count}}</b>{{/if}} edits to <a href="{{project_path}}/wiki/WP:BLP">biographies of living persons</a>
 
 <dl>

--- a/views/namespace_counter/summary.handlebars
+++ b/views/namespace_counter/summary.handlebars
@@ -2,7 +2,7 @@
   {{#if nonautomated}}Non-automated namespace{{else}}Namespace{{/if}} totals for <a href="{{project_path}}/wiki/User:{{username}}">{{username}}</a>
 </h3>
 
-{{#if replication_lag}}<p class='error'>High replication lag: Data newer than {{replication_lag}} seconds may not be shown</p>{{/if}}
+{{#if replication_lag}}<p class='error'>High replication lag: Data newer than {{replication_lag}} may not be shown</p>{{/if}}
 <dl class='namespaces'>
   <dt>Total edits</dt><dd>{{total_count}}</dd>
 </dl>

--- a/views/nonautomated_edits/summary.handlebars
+++ b/views/nonautomated_edits/summary.handlebars
@@ -1,4 +1,4 @@
-{{#if replication_lag}}<p class='error'>High replication lag: Data newer than {{replication_lag}} seconds may not be shown</p>{{/if}}
+{{#if replication_lag}}<p class='error'>High replication lag: Data newer than {{replication_lag}} may not be shown</p>{{/if}}
 <a href="{{project_path}}/wiki/User:{{username}}">{{username}}</a> has approximently <b>{{nonautomated_count}}</b> non-automated edits {{{namespace_str}}}
 
 {{#if namespace_text}}<p>Totals for the <b>{{namespace_text}}</b> namespace:</p>{{/if}}

--- a/views/policy_edits/summary.handlebars
+++ b/views/policy_edits/summary.handlebars
@@ -1,4 +1,4 @@
-{{#if replication_lag}}<p class='error'>High replication lag: Data newer than {{replication_lag}} seconds may not be shown</p>{{/if}}
+{{#if replication_lag}}<p class='error'>High replication lag: Data newer than {{replication_lag}} may not be shown</p>{{/if}}
 <a href="{{project_path}}/wiki/User:{{username}}">{{username}}</a> has approximently <b>{{pg_count}}</b> total {{#if nonautomated}}nonautomated{{/if}} edits to <a href="{{project_path}}/wiki/WP:POLICY">policies and guidelines</a>
 
 <dl>


### PR DESCRIPTION
The replication lag counter in all tools except category edits (which for whatever reason already has the changes I've made) currently shows units twice, for example:

> High replication lag: Data newer than 23 minutes seconds may not be shown

This is because (I think) wt.replag(time) returns a string including the unit, and then "seconds" is added afterwards. Removing the explicit seconds should fix.
